### PR TITLE
disable redis AOF to save disk space and CPU cycles

### DIFF
--- a/templates/master_config.tpl
+++ b/templates/master_config.tpl
@@ -1,4 +1,5 @@
 port 6380
 masterauth ${master_pass}
 requirepass ${master_pass}
-appendonly yes
+save 60 1000
+appendonly no

--- a/templates/slave_config.tpl
+++ b/templates/slave_config.tpl
@@ -1,5 +1,6 @@
 slaveof ${master_ip_address} 6380
 masterauth ${master_pass}
 requirepass ${master_pass}
-appendonly yes
+save 60 1000
+appendonly no
 port 6380


### PR DESCRIPTION
currently redis consumes gigabytes of disk space and takes too much time in case of recovery. As we do not store any critical data there, I propose to persist data just using snapshots and disable AOF https://redis.io/topics/persistence
